### PR TITLE
Upgrade to terraform 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get install -y kubectl
 EXPOSE 43220 4040
 
 # Install Terraform
-RUN curl https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip -o "$HOME/terraform_0.11.14_linux_amd64.zip"
-RUN unzip -o "$HOME/terraform_0.11.14_linux_amd64.zip" -d /bin/
+RUN curl https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip -o "$HOME/terraform_0.12.7_linux_amd64.zip"
+RUN unzip -o "$HOME/terraform_0.12.7_linux_amd64.zip" -d /bin/
 
 # Install the Fastly Terraform provider
 WORKDIR /go/src/github.com/terraform-providers

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,21 +19,18 @@ RUN apt-get install -y kubectl
 EXPOSE 43220 4040
 
 # Install Terraform
-RUN curl https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip -o "$HOME/terraform_0.11.7_linux_amd64.zip"
-RUN unzip -o "$HOME/terraform_0.11.7_linux_amd64.zip" -d /bin/
+RUN curl https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip -o "$HOME/terraform_0.11.14_linux_amd64.zip"
+RUN unzip -o "$HOME/terraform_0.11.14_linux_amd64.zip" -d /bin/
 
 # Install the Fastly Terraform provider
 WORKDIR /go/src/github.com/terraform-providers
-RUN git clone --branch v0.8.0 https://github.com/terraform-providers/terraform-provider-fastly.git
+RUN git clone --branch v0.9.0 https://github.com/terraform-providers/terraform-provider-fastly.git
 
 WORKDIR /go/src/github.com/terraform-providers/terraform-provider-fastly
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" && cp /go/src/github.com/terraform-providers/terraform-provider-fastly/terraform-provider-fastly /bin/terraform-provider-fastly
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" && cp /go/src/github.com/terraform-providers/terraform-provider-fastly/terraform-provider-fastly /bin/terraform-provider-fastly_v0.9.0
 
 WORKDIR /
 RUN rm -rf /go
-
-# Install our Terraform assets
-ADD terraformrc /root/.terraformrc
 
 RUN mkdir /tf
 WORKDIR /tf

--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 Fastly Config Build
 -------------------
 
-This is a simple container that contains Terraform, the Fastly provider for Terraform, and other components needed to build and test the [fastly-config](https://github.com/pantheon-systems/fastly-config) project.
+This is a simple container that contains Terraform, the Fastly provider for Terraform, and other components needed to build and test the [fastly-config](https://github.com/pantheon-systems/fastly-config) and [fastly-routes](https://github.com/pantheon-systems/fastly-routes) projects.
 
 We setup workdir to be /tf, and you can mount in terraform manifests.
 
 ## Building
 
 This repo is built automatically by Quay on every commit that is pushed to the GitHub repository.
+
+## Version
+
+[terraform](https://www.terraform.io/) - 0.12.7
+[terraform-provider-fastly](https://www.terraform.io/docs/providers/fastly/index.html) - 0.9.0

--- a/terraformrc
+++ b/terraformrc
@@ -1,3 +1,0 @@
-providers {
-  fastly = "/bin/terraform-provider-fastly"
-}


### PR DESCRIPTION
Bumped terraform to 0.12.7 (latest stable build)
Removed the .terraformrc as [it is deprecated and it can't specify provider versions](https://www.terraform.io/docs/commands/cli-config.html#deprecated-settings) causing an error that was a hard blocker for the terraform 0.12.X upgrade.
Updated to the [latest fastly provider version](https://github.com/terraform-providers/terraform-provider-fastly/blob/master/CHANGELOG.md#090-august-07-2019) as instructed by terraform upgrade guide.
Switched to the official supported versioning format for a terraform provider as [specified in the official documentation](https://www.terraform.io/docs/configuration-0-11/providers.html#plugin-names-and-versions).
Added version information to README